### PR TITLE
[#85] 쿠폰 관련 mock API 구현 및 연동

### DIFF
--- a/src/app/admin/coupon/register/page.tsx
+++ b/src/app/admin/coupon/register/page.tsx
@@ -8,9 +8,11 @@ import { useRouter } from "next/navigation"
 import ConfirmModal from "@/components/common/ConfirmModal"
 import { useApi } from "@/hooks/useApi"
 import TimePicker from "@/components/common/TimePicker"
+import OverlaySpinner from "@/components/common/OverlaySpinner"
 export default function CouponRegisterPage() {
     const router = useRouter();
     const { apiCall } = useApi();
+    const [isLoading, setIsLoading] = useState<boolean>(false) // 쿠폰 등록 중 로딩 상태
     const [isModalOpen, setIsModalOpen] = useState<boolean>(false)
     // 쿠폰 추가
     const [couponName, setCouponName] = useState<string>("")
@@ -26,13 +28,13 @@ export default function CouponRegisterPage() {
 
     const [couponPriceError, setCouponPriceError] = useState<boolean>(false);
     const [couponStockError, setCouponStockError] = useState<boolean>(false);
-
-    const isSameDate = couponStartDateTime.toDateString() === couponEndDateTime.toDateString()
     
     const disabled = couponName === "" || couponDescription === "" || couponPrice === 0 || couponStartDateTime === null || couponEndDateTime === null || couponExpireDateTime === null || couponStock === 0
 
     const handleAddCoupon = () => {
         // 쿠폰 등록 추가
+        setIsModalOpen(false);
+        setIsLoading(true)
         apiCall("/api/coupon/create", "POST", {
             title: couponName,
             content: couponDescription,
@@ -117,6 +119,9 @@ export default function CouponRegisterPage() {
 
     return (
         <div className="flex flex-col mx-auto w-full p-8 gap-6">
+            {
+                isLoading && <OverlaySpinner message="쿠폰 등록 중입니다." />
+            }
                 <div className="flex w-full">
                 <button className="text-sm text-gray-500 flex items-center gap-2" onClick={() => router.push("/admin/coupon")}>
                     <ArrowLeftIcon className="w-4 h-4" />

--- a/src/app/api/coupon/create/route.tsx
+++ b/src/app/api/coupon/create/route.tsx
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(request: NextRequest) {
+    const { 
+        title,
+        content,
+        price,
+        startAt,
+        endAt,
+        expiresAt,
+        stock,
+    } = await request.json()
+    
+    return NextResponse.json({
+        "id": 9007199254740991,
+        "code": 9007199254740991,
+        "title": title,
+        "content": content,
+        "price": price,
+        "startAt": startAt,
+        "endAt": endAt,
+        "expiresAt": expiresAt,
+        "stock": stock,
+        "status": "PREVIOUS"
+    })
+}

--- a/src/app/api/couponEvent/getActives/route.tsx
+++ b/src/app/api/couponEvent/getActives/route.tsx
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(request: NextRequest) {
+    return NextResponse.json([
+        {
+            "id": 9007199354740991,
+            "couponId": 9007199254740991,
+            "title": "string",
+            "content": "string",
+            "price": 1073741824,
+            "stock": 1073741824,
+            "expireAt": "2025-05-13T05:16:33.825Z",
+            "userIssued": false
+        },
+        {
+        "id": 9007199254740991,
+        "couponId": 9007196254740991,
+        "title": "string",
+        "content": "string",
+        "price": 1073741824,
+        "stock": 1073741824,
+        "expireAt": "2025-05-13T05:16:33.825Z",
+        "userIssued": true
+        },
+    ]);
+}

--- a/src/app/api/couponEvent/getActives/route.tsx
+++ b/src/app/api/couponEvent/getActives/route.tsx
@@ -9,7 +9,7 @@ export async function GET(request: NextRequest) {
             "content": "string",
             "price": 1073741824,
             "stock": 1073741824,
-            "expireAt": "2025-05-13T05:16:33.825Z",
+            "expires": "2025-05-13T05:16:33.825Z",
             "userIssued": false
         },
         {
@@ -19,7 +19,7 @@ export async function GET(request: NextRequest) {
         "content": "string",
         "price": 1073741824,
         "stock": 1073741824,
-        "expireAt": "2025-05-13T05:16:33.825Z",
+        "expires": "2025-05-13T05:16:33.825Z",
         "userIssued": true
         },
     ]);

--- a/src/app/api/userCoupon/route.tsx
+++ b/src/app/api/userCoupon/route.tsx
@@ -14,3 +14,38 @@ export async function POST(request: NextRequest) {
         "status": "UNUSED"
     })
 }
+
+export async function GET(request: NextRequest) {
+    return NextResponse.json([
+        {
+            "id": 9007199254740991,
+            "couponId": 9007199254740991,
+            "title": "string",
+            "content": "string",
+            "price": 1073741824,
+            "stock": 1073741824,
+            "expires": "2025-05-13T05:16:33.914Z",
+            "status": "UNUSED"
+        },
+        {
+            "id": 9007199254740991,
+            "couponId": 9007199254740991,
+            "title": "string",
+            "content": "string",
+            "price": 1073741824,
+            "stock": 1073741824,
+            "expires": "2025-05-13T05:16:33.914Z",
+            "status": "USED"
+        },
+        {
+            "id": 9007199254740991,
+            "couponId": 9007199254740991,
+            "title": "string",
+            "content": "string",
+            "price": 1073741824,
+            "stock": 1073741824,
+            "expires": "2025-05-13T05:16:33.914Z",
+            "status": "EXPIRED"
+        }
+    ])
+}

--- a/src/app/api/userCoupon/route.tsx
+++ b/src/app/api/userCoupon/route.tsx
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(request: NextRequest) {
+    const { couponId } = await request.json()
+
+    return NextResponse.json({
+        "id": 9007199254740991,
+        "couponId": 9007199254740991,
+        "title": "string",
+        "content": "string",
+        "price": 1073741824,
+        "stock": 1073741824,
+        "expires": "2025-05-13T05:16:33.918Z",
+        "status": "UNUSED"
+    })
+}

--- a/src/components/RegisterPageButtonLoader.tsx
+++ b/src/components/RegisterPageButtonLoader.tsx
@@ -4,7 +4,6 @@ import { usePathname } from "next/navigation";
 import RegisterPageButton from "../components/projectRegister/RegisterPageButton";
 export default function RegisterPageButtonLoader() {
     const pathname = usePathname();
-    console.log(pathname)
     if (pathname?.startsWith("/admin") || pathname === "/project/register" || pathname?.endsWith("/edit")) {
         return null;
     }

--- a/src/components/common/OverlaySpinner.tsx
+++ b/src/components/common/OverlaySpinner.tsx
@@ -1,12 +1,25 @@
 "use client"
 
+import { useEffect } from "react"
 import Spinner from "./Spinner"
 
 interface Props {
     message: string
 }
 
+
+
 export default function OverlaySpinner({ message }: Props) {
+    // 모달 뒷배경 스크롤 방지
+    useEffect(() => {
+        document.body.style.overflow = "hidden"
+
+        return () => {
+        // 모달이 닫힐 때 body 스크롤 복원
+        document.body.style.overflow = ""
+        }
+    }, [])
+
     return (
         <div className="fixed inset-0 bg-white/20 flex items-center justify-center z-50">
             <Spinner message={message} />

--- a/src/components/common/OverlaySpinner.tsx
+++ b/src/components/common/OverlaySpinner.tsx
@@ -1,0 +1,15 @@
+"use client"
+
+import Spinner from "./Spinner"
+
+interface Props {
+    message: string
+}
+
+export default function OverlaySpinner({ message }: Props) {
+    return (
+        <div className="fixed inset-0 bg-white/20 flex items-center justify-center z-50">
+            <Spinner message={message} />
+        </div>
+    )
+}

--- a/src/components/common/TimePicker.tsx
+++ b/src/components/common/TimePicker.tsx
@@ -1,0 +1,72 @@
+"use client"
+
+import { useState, useRef, useEffect } from "react"
+import { Clock } from "lucide-react"
+import clsx from "clsx"
+
+interface TimePickerProps {
+  selectedDateTime: Date
+  onChange: (hour: number) => void
+  minDateTime?: Date
+}
+
+export default function TimePicker({ selectedDateTime, onChange, minDateTime }: TimePickerProps) {
+  const [isOpen, setIsOpen] = useState(false)
+  const timePickerRef = useRef<HTMLDivElement>(null)
+  const hours = Array.from({ length: 24 }, (_, i) => i.toString().padStart(2, "0"))
+
+  const handleTimeSelect = (hour: string) => {
+    onChange(+hour)
+  }
+
+  const isBeforeMinTime = (hour: string) => selectedDateTime.getDate() === minDateTime?.getDate() && +hour <= minDateTime?.getHours()
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (timePickerRef.current && !timePickerRef.current.contains(event.target as Node)) {
+        setIsOpen(false)
+      }
+    }
+
+    document.addEventListener("click", handleClickOutside)
+    return () => {
+      document.removeEventListener("click", handleClickOutside)
+    }
+  }, [])
+
+  return (
+    <div className="relative" ref={timePickerRef}>
+      <div
+        className="flex rounded-full border border-gray-300 px-4 py-3 pl-10 focus:border-main-color focus:outline-none cursor-pointer"
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        <Clock className="w-5 h-5 text-gray-500 absolute left-4 top-1/2 -translate-y-1/2" />
+        <span>{selectedDateTime.getHours().toString().padStart(2, "0")}:00</span>
+      </div>
+
+      {isOpen && (
+        <div 
+          className="absolute z-50 mt-1 bg-white border rounded-lg shadow-lg w-32 p-4"
+        >
+          <div className="flex flex-col items-center max-h-[200px] overflow-y-auto overflow-x-hidden scrollbar-hide">
+            {hours.map((hour) => (
+              <button
+                key={hour}
+                disabled={isBeforeMinTime(hour)}
+                className={clsx(
+                  "w-fit p-2 text-sm rounded-md transition-all duration-200",
+                  "hover:bg-gray-100 focus:outline-none",
+                  selectedDateTime.getHours() === +hour ? "bg-main-color text-white scale-110" : "",
+                  isBeforeMinTime(hour) ? "text-gray-300" : ""
+                )}
+                onClick={() => handleTimeSelect(hour)}
+              >
+                {hour}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/header/CouponModal.tsx
+++ b/src/components/header/CouponModal.tsx
@@ -1,6 +1,9 @@
 "use client"
+import { useApi } from "@/hooks/useApi"
 import clsx from "clsx"
 import { Percent } from "lucide-react"
+import { useEffect, useState } from "react"
+import { CouponEvent } from "@/lib/couponInterface"
 
 interface CouponProps {
   isOpen: boolean
@@ -9,51 +12,20 @@ interface CouponProps {
 
 export default function CouponModal({ isOpen, onClose }: CouponProps) {
   if (!isOpen) return null
-
-  // mock data: 쿠폰 데이터 추후 삭제
-  const coupons = [
-    {
-      id: 1,
-      amount: "1000000원",
-      title: "~~~~ 쿠폰",
-      description:
-        "쿠폰 설명입니다. 쿠폰 설명입니다. 쿠폰 설명입니다. 쿠폰 설명입니다. 쿠폰 설명입니다. 쿠폰 설명입니다.",
-      validUntil: "2023-5-12까지 사용가능",
-      received: false,
-    },
-    {
-      id: 2,
-      amount: "1000000원",
-      title: "~~~~ 쿠폰",
-      description:
-        "쿠폰 설명입니다. 쿠폰 설명입니다. 쿠폰 설명입니다. 쿠폰 설명입니다. 쿠폰 설명입니다. 쿠폰 설명입니다.",
-      validUntil: "2023-5-12까지 사용가능",
-      received: false,
-    },
-    {
-      id: 3,
-      amount: "1000000원",
-      title: "~~~~ 쿠폰",
-      description:
-        "쿠폰 설명입니다. 쿠폰 설명입니다. 쿠폰 설명입니다. 쿠폰 설명입니다. 쿠폰 설명입니다. 쿠폰 설명입니다.",
-      validUntil: "2023-5-12까지 사용가능",
-      received: true,
-    },
-    {
-      id: 4,
-      amount: "1000000원",
-      title: "~~~~ 쿠폰",
-      description:
-        "쿠폰 설명입니다. 쿠폰 설명입니다. 쿠폰 설명입니다. 쿠폰 설명입니다. 쿠폰 설명입니다. 쿠폰 설명입니다.",
-      validUntil: "2023-5-12까지 사용가능",
-      received: true,
-    },
-  ]
+  const { apiCall } = useApi();
+  const [coupons, setCoupons] = useState<CouponEvent[]>([]);
 
   const handleGetCoupon = (couponId: number) => {
     // 쿠폰 발급 로직 추후 추가
     console.log(`쿠폰 ${couponId} 발급됨`)
   }
+  useEffect(() => {
+    apiCall("/api/couponEvent/getActives", "GET").then(({ data }) => {
+      if (data) {
+        setCoupons(data as CouponEvent[])
+      }
+    });
+  }, []);
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
@@ -68,25 +40,33 @@ export default function CouponModal({ isOpen, onClose }: CouponProps) {
           {coupons.map((coupon) => (
             <div key={coupon.id} className="rounded-xl border p-3">
               <div className="flex items-center justify-between">
+                <div className="flex flex-col">
                 <div className="flex items-center gap-3">
-                  <div className={clsx("flex h-10 w-10 items-center justify-center rounded-md text-white", coupon.received ? "bg-disabled-background" : "bg-main-color")}>
+                  <div className={clsx("flex h-10 w-10 items-center justify-center rounded-md text-white", coupon.userIssued ? "bg-disabled-background" : "bg-main-color")}>
                     <Percent className="h-5 w-5" />
                   </div>
                   <div>
-                    <div className={clsx("text-lg font-bold", coupon.received ? "text-disabled-color" : "text-main-color")}>{coupon.amount}</div>
+                    <div className={clsx("text-lg font-bold", coupon.userIssued ? "text-disabled-color" : "text-main-color")}>{coupon.price} 원</div>
                     <div className="text-sm font-medium">{coupon.title}</div>
                   </div>
+                  </div>
+                  <p className="mt-1 text-xs text-sub-gray">{coupon.content}</p>
+                  <p className="mt-0.5 text-xs text-sub-gray">{new Date(coupon.expireAt).toLocaleString('ko-KR', {year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit'}).replace(/\//g, '.').replace(',', '') + ' 만료'}</p>
                 </div>
-                <button
-                    type="button"
-                    className={clsx("rounded-full px-4 py-1.5 text-sm font-medium", coupon.received ? "bg-disabled-background text-disabled-color" : "bg-main-color text-white")}
-                    onClick={() => handleGetCoupon(coupon.id)}
-                >
-                  {coupon.received ? "발급완료" : "발급받기"}
-                </button>
+                <div className="flex flex-col items-end">
+                  <button
+                      type="button"
+                      className={clsx("rounded-full w-fit px-4 py-1.5 text-sm font-medium", coupon.userIssued ? "bg-disabled-background text-disabled-color" : "bg-main-color text-white")}
+                      onClick={() => handleGetCoupon(coupon.id)}
+                  >
+                    {coupon.userIssued ? "발급완료" : "발급받기"}
+                  </button>
+                  <div className="mt-1 text-xs text-sub-gray">
+                    {coupon.stock}개 남음
+                  </div>
+                </div>
               </div>
-              <p className="mt-1 text-xs text-sub-gray">{coupon.description}</p>
-              <p className="mt-0.5 text-xs text-sub-gray">{coupon.validUntil}</p>
+              
             </div>
           ))}
         </div>

--- a/src/components/header/CouponModal.tsx
+++ b/src/components/header/CouponModal.tsx
@@ -51,7 +51,7 @@ export default function CouponModal({ isOpen, onClose }: CouponProps) {
               </div>
               </div>
               <p className="mt-1 text-xs text-sub-gray">{coupon.content}</p>
-              <p className="mt-0.5 text-xs text-sub-gray">{new Date(coupon.expireAt).toLocaleString('ko-KR', {year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit'}).replace(/\//g, '.').replace(',', '') + ' 만료'}</p>
+              <p className="mt-0.5 text-xs text-sub-gray">{new Date(coupon.expires).toLocaleString('ko-KR', {year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit'}).replace(/\//g, '.').replace(',', '') + ' 만료'}</p>
             </div>
             <div className="flex flex-col items-end">
               <button

--- a/src/components/header/CouponModal.tsx
+++ b/src/components/header/CouponModal.tsx
@@ -18,8 +18,17 @@ export default function CouponModal({ isOpen, onClose }: CouponProps) {
   const [coupons, setCoupons] = useState<CouponEvent[]>([]);
 
   const handleGetCoupon = (couponId: number) => {
-    // 쿠폰 발급 로직 추후 추가
-    console.log(`쿠폰 ${couponId} 발급됨`)
+    apiCall("/api/userCoupon", "POST", { couponId }).then(() => {
+      loadCoupons()
+    })
+  }
+
+  const loadCoupons = () => {
+    apiCall("/api/couponEvent/getActives", "GET").then(({ data }) => {
+      if (data) {
+        setCoupons(data as CouponEvent[])
+      }
+    });
   }
 
   const renderCoupons = () => {
@@ -57,17 +66,13 @@ export default function CouponModal({ isOpen, onClose }: CouponProps) {
               </div>
             </div>
           </div>
-          
         </div>
       ))
     }
   }
+
   useEffect(() => {
-    apiCall("/api/couponEvent/getActives", "GET").then(({ data }) => {
-      if (data) {
-        setCoupons(data as CouponEvent[])
-      }
-    });
+    loadCoupons();
   }, []);
 
   return (

--- a/src/components/header/CouponModal.tsx
+++ b/src/components/header/CouponModal.tsx
@@ -4,6 +4,8 @@ import clsx from "clsx"
 import { Percent } from "lucide-react"
 import { useEffect, useState } from "react"
 import { CouponEvent } from "@/lib/couponInterface"
+import EmptyMessage from "../common/EmptyMessage"
+import Spinner from "../common/Spinner"
 
 interface CouponProps {
   isOpen: boolean
@@ -12,12 +14,53 @@ interface CouponProps {
 
 export default function CouponModal({ isOpen, onClose }: CouponProps) {
   if (!isOpen) return null
-  const { apiCall } = useApi();
+  const { apiCall, isLoading } = useApi();
   const [coupons, setCoupons] = useState<CouponEvent[]>([]);
 
   const handleGetCoupon = (couponId: number) => {
     // 쿠폰 발급 로직 추후 추가
     console.log(`쿠폰 ${couponId} 발급됨`)
+  }
+
+  const renderCoupons = () => {
+    if (isLoading) {
+      return <Spinner message="쿠폰 목록을 불러오고 있습니다."/>
+    } else if (coupons.length === 0) {
+      return <EmptyMessage message="발급 가능한 쿠폰이 없습니다." />
+    } else {
+      return coupons.map((coupon) => (
+        <div key={coupon.id} className="rounded-xl border p-3">
+          <div className="flex items-center justify-between">
+            <div className="flex flex-col">
+            <div className="flex items-center gap-3">
+              <div className={clsx("flex h-10 w-10 items-center justify-center rounded-md text-white", coupon.userIssued ? "bg-disabled-background" : "bg-main-color")}>
+                <Percent className="h-5 w-5" />
+              </div>
+              <div>
+                <div className={clsx("text-lg font-bold", coupon.userIssued ? "text-disabled-color" : "text-main-color")}>{coupon.price} 원</div>
+                <div className="text-sm font-medium">{coupon.title}</div>
+              </div>
+              </div>
+              <p className="mt-1 text-xs text-sub-gray">{coupon.content}</p>
+              <p className="mt-0.5 text-xs text-sub-gray">{new Date(coupon.expireAt).toLocaleString('ko-KR', {year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit'}).replace(/\//g, '.').replace(',', '') + ' 만료'}</p>
+            </div>
+            <div className="flex flex-col items-end">
+              <button
+                  type="button"
+                  className={clsx("rounded-full w-fit px-4 py-1.5 text-sm font-medium", coupon.userIssued ? "bg-disabled-background text-disabled-color" : "bg-main-color text-white")}
+                  onClick={() => handleGetCoupon(coupon.id)}
+              >
+                {coupon.userIssued ? "발급완료" : "발급받기"}
+              </button>
+              <div className="mt-1 text-xs text-sub-gray">
+                {coupon.stock}개 남음
+              </div>
+            </div>
+          </div>
+          
+        </div>
+      ))
+    }
   }
   useEffect(() => {
     apiCall("/api/couponEvent/getActives", "GET").then(({ data }) => {
@@ -37,38 +80,7 @@ export default function CouponModal({ isOpen, onClose }: CouponProps) {
         <h2 className="mb-4 text-left text-2xl font-bold">할인 쿠폰</h2>
 
         <div className="space-y-3">
-          {coupons.map((coupon) => (
-            <div key={coupon.id} className="rounded-xl border p-3">
-              <div className="flex items-center justify-between">
-                <div className="flex flex-col">
-                <div className="flex items-center gap-3">
-                  <div className={clsx("flex h-10 w-10 items-center justify-center rounded-md text-white", coupon.userIssued ? "bg-disabled-background" : "bg-main-color")}>
-                    <Percent className="h-5 w-5" />
-                  </div>
-                  <div>
-                    <div className={clsx("text-lg font-bold", coupon.userIssued ? "text-disabled-color" : "text-main-color")}>{coupon.price} 원</div>
-                    <div className="text-sm font-medium">{coupon.title}</div>
-                  </div>
-                  </div>
-                  <p className="mt-1 text-xs text-sub-gray">{coupon.content}</p>
-                  <p className="mt-0.5 text-xs text-sub-gray">{new Date(coupon.expireAt).toLocaleString('ko-KR', {year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit'}).replace(/\//g, '.').replace(',', '') + ' 만료'}</p>
-                </div>
-                <div className="flex flex-col items-end">
-                  <button
-                      type="button"
-                      className={clsx("rounded-full w-fit px-4 py-1.5 text-sm font-medium", coupon.userIssued ? "bg-disabled-background text-disabled-color" : "bg-main-color text-white")}
-                      onClick={() => handleGetCoupon(coupon.id)}
-                  >
-                    {coupon.userIssued ? "발급완료" : "발급받기"}
-                  </button>
-                  <div className="mt-1 text-xs text-sub-gray">
-                    {coupon.stock}개 남음
-                  </div>
-                </div>
-              </div>
-              
-            </div>
-          ))}
+          {renderCoupons()}
         </div>
 
         <div className="mt-4 flex justify-end">

--- a/src/components/profile/CouponList.tsx
+++ b/src/components/profile/CouponList.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import { UserCoupon } from "@/lib/couponInterface";
+import clsx from "clsx";
+import { Percent } from "lucide-react";
+
+export default function CouponList({ coupons }: { coupons: UserCoupon[] }) {
+
+    const couponStateMessage = (state: string, expiredDate: string) => {
+        const expiredDateString = new Date(expiredDate).toLocaleDateString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' });
+        if (state === "UNUSED") {
+          return `${expiredDateString}까지 사용가능`
+        } else if (state === "USED") {
+          return "사용완료"
+        } else if (state === "EXPIRED") {
+          return `${expiredDateString} 만료`
+        }
+    }
+
+    return (
+        <div className="flex flex-col gap-4">
+          {coupons.map((coupon) => (
+          <div className="rounded-2xl border border-gray-border flex overflow-hidden" key={coupon.id}>
+            {/* 왼쪽: 퍼센트 아이콘 */}
+            <div className={clsx("relative min-w-[70px] h-[100px] flex items-center justify-center", coupon.status === "UNUSED" ? "bg-main-color" : "bg-disabled-background")}>
+              <div className="absolute top-0 right-0 w-4 h-4 bg-white rounded-full translate-x-1/2 translate-y-[-50%]"></div>
+              <div className="absolute bottom-0 right-0 w-4 h-4 bg-white rounded-full translate-x-1/2 translate-y-[50%]"></div>
+              <Percent className="h-8 w-8 text-white" />
+            </div>
+      
+            {/* 중앙: 쿠폰 제목 및 설명 */}
+            <div className="flex-1 p-4 flex flex-col justify-center">
+              <h3 className="text-lg font-bold">{coupon.title}</h3>
+              <p className="text-sm text-sub-gray mt-1">{coupon.content}</p>
+            </div>
+      
+            {/* 구분선 */}
+            <div className="w-0 border-l border-dashed border-gray-border my-4"></div>
+      
+            {/* 오른쪽: 금액 및 유효기간 */}
+            <div className="p-4 flex flex-col justify-center items-end w-60">
+              <p className={clsx("text-xl font-bold", coupon.status === "UNUSED" ? "text-main-color" : "text-disabled-text")}>{coupon.price} 원</p>
+              <p className="text-xs text-sub-gray mt-1">
+                {couponStateMessage(coupon.status, coupon.expires)}
+              </p>
+            </div>
+          </div>
+        ))}
+        </div>
+    )
+}

--- a/src/components/profile/ProfileContent.tsx
+++ b/src/components/profile/ProfileContent.tsx
@@ -11,6 +11,9 @@ import MyProjectList from "./MyProjectList"
 import clsx from "clsx"
 import { useApi } from "@/hooks/useApi"
 import { UserCoupon } from "@/lib/couponInterface"
+import CouponList from "./CouponList"
+import Spinner from "../common/Spinner"
+import EmptyMessage from "../common/EmptyMessage"
 
 interface ProfileContentProps {
   introduction: string
@@ -179,16 +182,7 @@ export default function ProfileContent({ introduction, links, isMy }: ProfileCon
     },
   ]
 
-  const couponStateMessage = (state: string, expiredDate: string) => {
-    const expiredDateString = new Date(expiredDate).toLocaleDateString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' });
-    if (state === "UNUSED") {
-      return `${expiredDateString}까지 사용가능`
-    } else if (state === "USED") {
-      return "사용완료"
-    } else if (state === "EXPIRED") {
-      return `${expiredDateString} 만료`
-    }
-  }
+  
 
   // 팔로우 버튼 클릭 핸들러
   const handleFollow = (userId: number) => {
@@ -204,6 +198,16 @@ export default function ProfileContent({ introduction, links, isMy }: ProfileCon
 
   const loadUserCoupon = () => {
     apiCall("/api/userCoupon", "GET").then(({ data }) => setUserCoupons(data as UserCoupon[]))
+  }
+
+  const renderCouponList = () => {
+    if (isLoading) {
+      return <Spinner message="쿠폰 목록을 불러오고 있습니다." />
+    } else if (userCoupons.length === 0) {
+      return <EmptyMessage message="쿠폰이 없습니다." />
+    } else {
+      return <CouponList coupons={userCoupons} />
+    }
   }
 
   useEffect(() => {
@@ -306,35 +310,8 @@ export default function ProfileContent({ introduction, links, isMy }: ProfileCon
           </div>
         )}
 
-        {activeTab === "쿠폰" && <div className="flex flex-col gap-4">
-          {userCoupons.map((coupon) => (
-          <div className="rounded-2xl border border-gray-border flex overflow-hidden" key={coupon.id}>
-            {/* 왼쪽: 퍼센트 아이콘 */}
-            <div className={clsx("relative min-w-[70px] h-[100px] flex items-center justify-center", coupon.status === "UNUSED" ? "bg-main-color" : "bg-disabled-background")}>
-              <div className="absolute top-0 right-0 w-4 h-4 bg-white rounded-full translate-x-1/2 translate-y-[-50%]"></div>
-              <div className="absolute bottom-0 right-0 w-4 h-4 bg-white rounded-full translate-x-1/2 translate-y-[50%]"></div>
-              <Percent className="h-8 w-8 text-white" />
-            </div>
-      
-            {/* 중앙: 쿠폰 제목 및 설명 */}
-            <div className="flex-1 p-4 flex flex-col justify-center">
-              <h3 className="text-lg font-bold">{coupon.title}</h3>
-              <p className="text-sm text-sub-gray mt-1">{coupon.content}</p>
-            </div>
-      
-            {/* 구분선 */}
-            <div className="w-0 border-l border-dashed border-gray-border my-4"></div>
-      
-            {/* 오른쪽: 금액 및 유효기간 */}
-            <div className="p-4 flex flex-col justify-center items-end w-60">
-              <p className={clsx("text-xl font-bold", coupon.status === "UNUSED" ? "text-main-color" : "text-disabled-text")}>{coupon.price} 원</p>
-              <p className="text-xs text-sub-gray mt-1">
-                {couponStateMessage(coupon.status, coupon.expires)}
-              </p>
-            </div>
-          </div>
-        ))}
-        </div>
+        {activeTab === "쿠폰" && 
+            renderCouponList()
         }
       </div>
     </div>

--- a/src/components/projectRegister/DatePicker.tsx
+++ b/src/components/projectRegister/DatePicker.tsx
@@ -140,13 +140,6 @@ export default function DatePicker({ selectedDate, onChange, position = "top", m
     }
   }, [isOpen, selectedDate])
 
-  // 최소 날짜가 변경되었을 때 선택된 날짜가 최소 날짜보다 이전이면 최소 날짜로 설정
-  useEffect(() => {
-    if (minDate && selectedDate < minDate) {
-      onChange(new Date(minDate))
-    }
-  }, [minDate, selectedDate, onChange])
-
   return (
     <div className="relative" ref={datePickerRef}>
       <div className="relative">

--- a/src/lib/couponInterface.ts
+++ b/src/lib/couponInterface.ts
@@ -5,8 +5,19 @@ interface CouponEvent {
     content: string;
     price: number;
     stock: number;
-    expireAt: string;
+    expires: string;
     userIssued: boolean;
 }
 
-export type { CouponEvent };
+interface UserCoupon {
+    id: number,
+    couponId: number,
+    title: string,
+    content: string,
+    price: number,
+    stock: number,
+    expires: string,
+    status: string,
+}
+
+export type { CouponEvent, UserCoupon };

--- a/src/lib/couponInterface.ts
+++ b/src/lib/couponInterface.ts
@@ -1,0 +1,12 @@
+interface CouponEvent {
+    id: number;
+    couponId: number;
+    title: string;
+    content: string;
+    price: number;
+    stock: number;
+    expireAt: string;
+    userIssued: boolean;
+}
+
+export type { CouponEvent };


### PR DESCRIPTION
## Summary

>- close [#85]

## Tasks
- 헤더 쿠폰 이벤트 모달: 이벤트 조회 mock api 구현 및 연동
- 헤더 쿠폰 이벤트 모달: 로딩 & 쿠폰 없음 상태 추가
- 헤더 쿠폰 이벤트 모달: 유저 쿠폰 생성(쿠폰 발급) mock api 구현 및 연동
- 관리자 쿠폰 등록 페이지: 쿠폰 추가 mock api 구현 및 연동
- 관리자 쿠폰 등록 페이지: 쿠폰 등록 로딩 상태 추가 (공통 컴포넌트 OverlaySpinner 추가)
- 마이페이지 쿠폰 메뉴: 사용자 쿠폰 조회 mock api 구현 및 연동
- 마이페이지 쿠폰 메뉴: 로딩 & 쿠폰 없음 상태 추가

## To Reviewer
1. 마이페이지에서 쿠폰을 load하고 컴포넌트에 전해주는 방식입니다.
쿠폰 load의 책임을 컴포넌트에 주는게 좋을까요? 아니면 한 번만 불러와서 계속 페이지에서 사용하는 게 나을까요?

2. 관리자 페이지의 쿠폰 조회는 백엔드 구현시 추가합니다.

3. 에러 시 UI를 어떻게 보여줄지 생각해야할 것 같습니다.

## Screenshot
