### PR TITLE
Task/#180

### DIFF
--- a/src/components/common/ProjectGridItem.tsx
+++ b/src/components/common/ProjectGridItem.tsx
@@ -85,8 +85,8 @@ export default function ProjectCard({
 
         <div className="flex flex-col flex-1 justify-between p-1 pt-2">
           <div>
-            <p className={clsx("text-sub-gray", sizeDesign.sellerName[size])}>{sellerName}</p>
-            <p className={clsx("font-medium line-clamp-2", sizeDesign.projectName[size])}>{projectName}</p>
+            <p className={clsx("text-sub-gray line-clamp-1", sizeDesign.sellerName[size])}>{sellerName}</p>
+            <p className={clsx("font-medium line-clamp-1", sizeDesign.projectName[size])}>{projectName}</p>
             <p className={clsx("text-sub-gray mt-1 line-clamp-2", sizeDesign.description[size])}>{description}</p>
             { !showProgressBar && <p
               className={cn("font-bold mt-1", isOverAchieved ? "text-point-color" : "text-main-color", isSoldOut ? "text-sub-gray" : "text-main-color", sizeDesign.achievement[size])}

--- a/src/components/list/CategoryMenu.tsx
+++ b/src/components/list/CategoryMenu.tsx
@@ -56,7 +56,11 @@ export default function CategoryMenu({ categoryId, handleCategoryError }: Catego
     return (
         <div className="w-full mx-0 py-4" data-cy="category-list">
         {isLoading ?
-            <Spinner message="카테고리를 불러오는 중입니다..." />
+            <div className="flex gap-4">
+                {[...Array(3)].map((_, i) => (
+                    <div key={i} className="w-20 h-12 rounded-lg bg-gray-200 animate-pulse" />
+                ))}
+            </div>
         : (
         <div
             className="flex overflow-x-auto gap-4 justify-items-center [&::-webkit-scrollbar]:hidden"

--- a/src/components/list/CategoryMenu.tsx
+++ b/src/components/list/CategoryMenu.tsx
@@ -58,7 +58,7 @@ export default function CategoryMenu({ categoryId, handleCategoryError }: Catego
         {isLoading ?
             <div className="flex gap-4">
                 {[...Array(3)].map((_, i) => (
-                    <div key={i} className="w-20 h-12 rounded-lg bg-gray-200 animate-pulse" />
+                    <div key={i} className={`w-20 h-12 rounded-lg bg-gray-${3 - i}00 animate-pulse`} />
                 ))}
             </div>
         : (

--- a/src/components/list/ListPage.tsx
+++ b/src/components/list/ListPage.tsx
@@ -17,7 +17,7 @@ interface ListPageProps {
 
 export default function ListPage({ type, categoryId, searchWord }: ListPageProps) {
   const { isLoading, apiCall } = useApi();
-  const [projects, setProjects] = useState<listProject[]>([]);
+  const [projects, setProjects] = useState<listProject[] | undefined>(undefined);
   const [cursorValue, setCursorValue] = useState<string | null>(null);
   const [lastProjectId, setLastProjectId] = useState<number | null>(null);
   const [totalCount, setTotalCount] = useState(0);
@@ -38,7 +38,7 @@ export default function ListPage({ type, categoryId, searchWord }: ListPageProps
       if(sort === newSort) return;
       setCursorValue(null);
       setLastProjectId(null);
-      setProjects([]);
+      setProjects(undefined);
       setSort(newSort);
   }
 
@@ -49,7 +49,8 @@ export default function ListPage({ type, categoryId, searchWord }: ListPageProps
         console.log(error);
         setLoadError(true);
       } else {
-        if ("content" in data) setProjects([...projects, ...(data.content as listProject[])]);
+        if ("content" in data) setProjects(prev => prev ? [...prev, ...(data.content as listProject[])] : [...(data.content as listProject[])]);
+        else setProjects([]);
         if ("nextCursorValue" in data) setCursorValue(data.nextCursorValue as string | null);
         if ("nextProjectId" in data) setLastProjectId(data.nextProjectId as number | null); 
         if (totalCount === 0 && "total" in data) setTotalCount(data.total as number);
@@ -82,6 +83,7 @@ export default function ListPage({ type, categoryId, searchWord }: ListPageProps
     const resetAndLoad = async () => {
       setCursorValue(null);
       setLastProjectId(null);
+      setProjects(undefined);
       loadProjects();
     };
     resetAndLoad();
@@ -96,7 +98,7 @@ export default function ListPage({ type, categoryId, searchWord }: ListPageProps
             sort={sort}
             onClickSort={handleSortClick}
         /> 
-        {(!loadError || projects.length > 0) && <ProjectsList projects={projects} isLoading={isLoading} />}
+        {(!loadError || (projects && projects.length > 0)) && <ProjectsList projects={projects} isLoading={isLoading} />}
         { 
             !loadError && morePage && 
             <div className="w-full py-20 flex justify-center items-center" ref={loader} data-cy="loading-spinner">

--- a/src/components/list/ListPage.tsx
+++ b/src/components/list/ListPage.tsx
@@ -36,9 +36,6 @@ export default function ListPage({ type, categoryId, searchWord }: ListPageProps
 
   const handleSortClick = (newSort: string) => {
       if(sort === newSort) return;
-      setCursorValue(null);
-      setLastProjectId(null);
-      setProjects(undefined);
       setSort(newSort);
   }
 
@@ -74,20 +71,20 @@ export default function ListPage({ type, categoryId, searchWord }: ListPageProps
     return () => observer.disconnect();
   }, [isLoading, morePage]);
 
-
+  // 정렬 조건이 바뀌면 상태만 초기화
   useEffect(() => {
-    loadProjects();
-  }, []);
+    setCursorValue(null);
+    setLastProjectId(null);
+    setProjects(undefined);
+  }, [sort]);
 
+  // cursorValue, lastProjectId가 null로 초기화된 후에만 loadProjects 실행
   useEffect(() => {
-    const resetAndLoad = async () => {
-      setCursorValue(null);
-      setLastProjectId(null);
-      setProjects(undefined);
+    if (cursorValue === null && lastProjectId === null) {
       loadProjects();
-    };
-    resetAndLoad();
-  }, [sort])
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cursorValue, lastProjectId, sort]);
 
   return (
     <div className="w-full w-[var(--content-width)]">

--- a/src/components/list/ProjectsList.tsx
+++ b/src/components/list/ProjectsList.tsx
@@ -14,11 +14,11 @@ export default function ProjectsList({ projects, isLoading }: {
         endAt: string
         daysLeft: number
         views: number
-    }[]
+    }[] | undefined
     isLoading: boolean
 }) {
     const renderList = () => {
-        if (projects.length === 0 && isLoading) return (
+        if (projects === undefined) return (
             <div className="w-full min-h-[300px] grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-y-20 gap-x-[10px] justify-items-center" data-cy="project-list-skeleton">
                 {[...Array(20)].map((_, i) => (
                     <div key={i} className="flex flex-col rounded-lg overflow-hidden animate-pulse w-full min-w-[160px] max-w-[95vw] sm:min-w-[180px] sm:max-w-xs p-2">
@@ -45,27 +45,27 @@ export default function ProjectsList({ projects, isLoading }: {
         )
         else if (projects.length === 0) return <EmptyMessage message="프로젝트가 없습니다." />
         else 
-            return (
-                <div
-                    className="w-fit grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-y-20 gap-x-[10px] justify-items-center"
-                    data-cy="project-list"
-                >
-                    {projects.map((project) => (
-                        <ProjectCard
-                            className="w-full"
-                            key={project.id}
-                            id={project.id}
-                            imageUrl={project.imageUrl}
-                            sellerName={project.sellerName}
-                            projectName={project.title}
-                            achievementRate={project.achievementRate}
-                            description={project.description}
-                            daysLeft={project.daysLeft}
-                            showProgressBar={true}
-                        />
-                    ))}
-                </div>
-            )
+        return (
+            <div
+                className="w-fit grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-y-20 gap-x-[10px] justify-items-center"
+                data-cy="project-list"
+            >
+                {projects.map((project) => (
+                    <ProjectCard
+                    className="w-full"
+                    key={project.id}
+                    id={project.id}
+                    imageUrl={project.imageUrl}
+                    sellerName={project.sellerName}
+                    projectName={project.title}
+                    achievementRate={project.achievementRate}
+                    description={project.description}
+                    daysLeft={project.daysLeft}
+                    showProgressBar={true}
+                  />
+                ))}
+            </div>
+        )
     }
   return (
     <div className="flex flex-col items-center">

--- a/src/components/list/ProjectsList.tsx
+++ b/src/components/list/ProjectsList.tsx
@@ -18,30 +18,54 @@ export default function ProjectsList({ projects, isLoading }: {
     isLoading: boolean
 }) {
     const renderList = () => {
-        if (projects.length === 0 && isLoading) return <Spinner message="프로젝트를 불러오는 중입니다." />
-        else if (projects.length === 0) return <EmptyMessage message="프로젝트가 없습니다." />
-        else 
-        return (
-            <div
-                className="w-fit grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-y-20 gap-x-[10px] justify-items-center"
-                data-cy="project-list"
-            >
-                {projects.map((project) => (
-                    <ProjectCard
-                    className="w-full"
-                    key={project.id}
-                    id={project.id}
-                    imageUrl={project.imageUrl}
-                    sellerName={project.sellerName}
-                    projectName={project.title}
-                    achievementRate={project.achievementRate}
-                    description={project.description}
-                    daysLeft={project.daysLeft}
-                    showProgressBar={true}
-                  />
+        if (projects.length === 0 && isLoading) return (
+            <div className="w-full min-h-[300px] grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-y-20 gap-x-[10px] justify-items-center" data-cy="project-list-skeleton">
+                {[...Array(20)].map((_, i) => (
+                    <div key={i} className="flex flex-col rounded-lg overflow-hidden animate-pulse w-full min-w-[160px] max-w-[95vw] sm:min-w-[180px] sm:max-w-xs p-2">
+                        <div className="relative overflow-hidden rounded-lg aspect-square bg-gray-200 mb-3" />
+                        <div className="flex flex-col flex-1 justify-between p-1 pt-2">
+                            <div>
+                                <div className="h-3 w-1/3 bg-gray-200 rounded mb-1" />
+                                <div className="h-4 w-2/3 bg-gray-300 rounded mb-1" />
+                                <div className="h-3 w-1/2 bg-gray-100 rounded mb-14" />
+                            </div>
+                            <div>
+                                <div className="h-3 w-1/3 bg-gray-200 rounded mb-1" />
+                                <div className="mt-1">
+                                    <div className="relative w-full h-3 bg-gray-100 rounded-full overflow-hidden mb-1" />
+                                    <div className="flex justify-end mt-1">
+                                        <div className="h-3 w-1/4 bg-gray-200 rounded" />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 ))}
             </div>
         )
+        else if (projects.length === 0) return <EmptyMessage message="프로젝트가 없습니다." />
+        else 
+            return (
+                <div
+                    className="w-fit grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-y-20 gap-x-[10px] justify-items-center"
+                    data-cy="project-list"
+                >
+                    {projects.map((project) => (
+                        <ProjectCard
+                            className="w-full"
+                            key={project.id}
+                            id={project.id}
+                            imageUrl={project.imageUrl}
+                            sellerName={project.sellerName}
+                            projectName={project.title}
+                            achievementRate={project.achievementRate}
+                            description={project.description}
+                            daysLeft={project.daysLeft}
+                            showProgressBar={true}
+                        />
+                    ))}
+                </div>
+            )
     }
   return (
     <div className="flex flex-col items-center">

--- a/src/components/main/Carousel.tsx
+++ b/src/components/main/Carousel.tsx
@@ -118,7 +118,30 @@ export default function Carousel({ projects, isLoading }: { projects: MainProjec
   }, [CARD_WIDTH, GAP, projects]);
 
   if (!projects || projects.length === 0) {
-    return <div className="flex justify-center items-center h-80">로딩 중입니다.</div>
+    return (
+      <div className="w-full bg-secondary-color flex flex-col items-center justify-center py-16 select-none">
+        <div
+          className="relative w-full max-w-full mx-auto flex items-center justify-center overflow-hidden"
+          style={{ height: CARD_HEIGHT }}
+        >
+          <div className="flex items-center justify-center mx-auto gap-4 w-full">
+            {[0,1,2,3,4].map(i => (
+              <div
+                key={i}
+                className="rounded-2xl bg-gray-200 animate-pulse flex-shrink-0 relative shadow-xl"
+                style={{
+                  width: '60%',
+                  height: CARD_HEIGHT,
+                  aspectRatio: '16/12',
+                  marginLeft: i === 0 ? 0 : 16,
+                  marginRight: i === 4 ? 0 : 16,
+                }}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    );
   }
 
   return (

--- a/src/components/main/Carousel.tsx
+++ b/src/components/main/Carousel.tsx
@@ -117,28 +117,54 @@ export default function Carousel({ projects, isLoading }: { projects: MainProjec
     };
   }, [CARD_WIDTH, GAP, projects]);
 
+  // 스켈레톤 높이만 동적으로 적용
+  const [skeletonHeight, setSkeletonHeight] = useState(0); // 초기값 0
+  useEffect(() => {
+    const getHeight = () => {
+      if (typeof window !== 'undefined') {
+        if (window.innerWidth < 640) return 165;
+        if (window.innerWidth < 1024) return 240;
+      }
+      return 300;
+    };
+    setSkeletonHeight(getHeight());
+    const handleResize = () => setSkeletonHeight(getHeight());
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
   if (!projects || projects.length === 0) {
     return (
       <div className="w-full bg-secondary-color flex flex-col items-center justify-center py-16 select-none">
         <div
           className="relative w-full max-w-full mx-auto flex items-center justify-center overflow-hidden"
-          style={{ height: CARD_HEIGHT }}
+          style={{ height: skeletonHeight || undefined }}
         >
-          <div className="flex items-center justify-center mx-auto gap-4 w-full">
+          <div className="flex items-center justify-center mx-auto w-full gap-2 sm:gap-4 lg:gap-8">
             {[0,1,2,3,4].map(i => (
               <div
                 key={i}
-                className="rounded-2xl bg-gray-200 animate-pulse flex-shrink-0 relative shadow-xl"
+                className="rounded-2xl bg-gray-200 animate-pulse flex-shrink-0 relative shadow-xl h-[165px] sm:h-[240px] lg:h-[300px]"
                 style={{
                   width: '60%',
-                  height: CARD_HEIGHT,
+                  height: skeletonHeight || undefined,
                   aspectRatio: '16/12',
-                  marginLeft: i === 0 ? 0 : 16,
-                  marginRight: i === 4 ? 0 : 16,
                 }}
               />
             ))}
           </div>
+        </div>
+        {/* 인디케이터 스켈레톤 */}
+        <div className="flex justify-center gap-2 mt-8">
+          {[0,1,2,3,4].map(i => (
+            <div
+              key={i}
+              className="w-3 h-3 rounded-full bg-gray-200 animate-pulse"
+              style={{
+                width: i === 2 ? '24px' : '12px'  // 중앙 인디케이터는 더 길게
+              }}
+            />
+          ))}
         </div>
       </div>
     );
@@ -173,11 +199,11 @@ export default function Carousel({ projects, isLoading }: { projects: MainProjec
             const project = projects[idx];
             if (!project) return null;
             // i === 2가 중앙, i === 1/3이 양옆, i === 0/4가 바깥쪽
-            let scale = 0.92, opacity = 0.7, zIndex = 1, boxShadow = '0 4px 16px 0 rgba(0,0,0,0.10)';
+            let opacity = 0.7, zIndex = 1, boxShadow = '0 4px 16px 0 rgba(0,0,0,0.10)';
             if (i === 2) {
-              scale = 1; opacity = 1; zIndex = 2; boxShadow = '0 8px 32px 0 rgba(0,0,0,0.18)';
+              opacity = 1; zIndex = 2; boxShadow = '0 8px 32px 0 rgba(0,0,0,0.18)';
             } else if (i === 1 || i === 3) {
-              scale = 0.96; opacity = 0.85; zIndex = 1; boxShadow = '0 4px 16px 0 rgba(0,0,0,0.10)';
+              opacity = 0.85; zIndex = 1; boxShadow = '0 4px 16px 0 rgba(0,0,0,0.10)';
             }
             return (
               <div
@@ -190,7 +216,6 @@ export default function Carousel({ projects, isLoading }: { projects: MainProjec
                 style={{
                   width: '60%',
                   height: CARD_HEIGHT,
-                  transform: `scale(${scale})`,
                   opacity,
                   zIndex,
                   boxShadow,

--- a/src/components/main/EditorPicks.tsx
+++ b/src/components/main/EditorPicks.tsx
@@ -95,7 +95,41 @@ export default function EditorPicks({ projects, isLoading }: {projects: MainProj
   }, [projects])
 
   if (projects === null || projects.length === 0) {
-    return <div>로딩 중입니다.</div>
+    return (
+      <div className="w-full max-w-7xl mx-auto py-12">
+        <div className="flex flex-col lg:flex-row items-start lg:items-center">
+          {/* Title */}
+          <h2 className="text-left font-bold mb-8 lg:mb-0 lg:min-w-[300px] pl-4 text-base sm:text-lg md:text-xl lg:text-3xl">
+            <span className="block lg:hidden">
+              에디터가 <span className="text-main-color">엄선한</span> 프로젝트를 확인해보세요
+            </span>
+            <span className="hidden lg:block">
+              에디터가<br />
+              <span className="text-main-color">엄선한</span> 프로젝트를<br />
+              확인해보세요
+            </span>
+          </h2>
+          {/* Carousel Container */}
+          <div className="relative flex-1 w-full min-w-[min(100vw,900px)] overflow-hidden">
+            <div className="pointer-events-none absolute left-0 top-0 h-full w-60 bg-gradient-to-r from-white to-transparent z-4" />
+            <div className="pointer-events-none absolute right-0 top-0 h-full w-60 bg-gradient-to-l from-white to-transparent z-4" />
+            <div className="flex w-fit gap-6">
+              {[0,1,2,3,4,5].map(i => (
+                <div
+                  key={i}
+                  className="flex flex-col items-start animate-pulse"
+                  style={{ minWidth: '220px', width: 220 }}
+                >
+                  <div className="w-full aspect-square bg-gray-200 rounded-lg mb-3" />
+                  <div className="h-5 w-2/3 bg-gray-200 rounded mb-2" />
+                  <div className="h-4 w-1/2 bg-gray-100 rounded" />
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    );
   }
 
   return (

--- a/src/components/main/EditorPicks.tsx
+++ b/src/components/main/EditorPicks.tsx
@@ -52,7 +52,7 @@ export default function EditorPicks({ projects, isLoading }: {projects: MainProj
         gsap.to(card, { scale: 0.84, zIndex: 0, duration: 0.3, ease: 'power2.out' })
       }
     })
-  }, [hoveredIndex])
+  }, [hoveredIndex, projects])
 
   // 무한 슬라이드용: 리스트 2배 복제
   const infiniteProjects = [...projects, ...projects]
@@ -98,6 +98,7 @@ export default function EditorPicks({ projects, isLoading }: {projects: MainProj
     return (
       <div className="w-full max-w-7xl mx-auto py-12">
         <div className="flex flex-col lg:flex-row items-start lg:items-center">
+          
           {/* Title */}
           <h2 className="text-left font-bold mb-8 lg:mb-0 lg:min-w-[300px] pl-4 text-base sm:text-lg md:text-xl lg:text-3xl">
             <span className="block lg:hidden">
@@ -109,6 +110,7 @@ export default function EditorPicks({ projects, isLoading }: {projects: MainProj
               확인해보세요
             </span>
           </h2>
+
           {/* Carousel Container */}
           <div className="relative flex-1 w-full min-w-[min(100vw,900px)] overflow-hidden">
             <div className="pointer-events-none absolute left-0 top-0 h-full w-60 bg-gradient-to-r from-white to-transparent z-4" />
@@ -118,11 +120,13 @@ export default function EditorPicks({ projects, isLoading }: {projects: MainProj
                 <div
                   key={i}
                   className="flex flex-col items-start animate-pulse"
-                  style={{ minWidth: '220px', width: 220 }}
+                  style={{ minWidth: '220px', width: 220, transform: 'scale(0.92)' }}
                 >
                   <div className="w-full aspect-square bg-gray-200 rounded-lg mb-3" />
-                  <div className="h-5 w-2/3 bg-gray-200 rounded mb-2" />
-                  <div className="h-4 w-1/2 bg-gray-100 rounded" />
+                  <div className="h-3 w-1/3 bg-gray-100 rounded mb-2" />
+                  <div className="h-3 w-full bg-gray-200 rounded mb-3" />
+                  <div className="h-6 w-full bg-gray-100 rounded mb-2" />
+                  <div className="h-3 w-1/4 bg-gray-200 rounded mb-2" />
                 </div>
               ))}
             </div>
@@ -161,7 +165,7 @@ export default function EditorPicks({ projects, isLoading }: {projects: MainProj
                 className="w-full project-card-anim transition-transform"
                 onMouseEnter={() => setHoveredIndex(index % projects.length)}
                 onMouseLeave={() => setHoveredIndex(null)}
-                style={{ willChange: 'transform', minWidth: '220px', maxWidth: '1fr' }}
+                style={{ willChange: 'transform', minWidth: '220px', maxWidth: '1fr', transform: 'scale(0.92)' }}
               >
                 <ProjectGridItem
                   className="w-full"

--- a/src/components/main/Top5.tsx
+++ b/src/components/main/Top5.tsx
@@ -31,6 +31,7 @@ export default function TopFive() {
   })
   const rank1Project = categoryProjects[activeTab] ? categoryProjects[activeTab][0] : null;
   const restProject = categoryProjects[activeTab] ? categoryProjects[activeTab].slice(1) : [];
+  const top5Projects = categoryProjects[activeTab] || [];
 
   const loadProjects = () => {
     apiCall<Response>("/api/project/categoryRankingView", "GET").then(({ data }) => {
@@ -66,8 +67,38 @@ export default function TopFive() {
     loadProjects();
   }, [])
 
-  if (categories === null) {
-    return <div>로딩 중입니다.</div> // 로딩 표시 필요
+  if (isLoading || top5Projects.length === 0) {
+    return (
+      <div className="w-full max-w-7xl mx-auto px-4 py-12">
+        <div className="flex items-center mb-8">
+          <h2 className="text-2xl font-bold">
+            BEST <span className="text-main-color">TOP 5</span> <span className="text-2xl">🏆</span>
+          </h2>
+        </div>
+        <div className="flex justify-between mb-8">
+          <div className="flex flex-wrap gap-2">
+            {[0,1,2].map(i => (
+              <div key={i} className="px-4 py-2 rounded-full bg-gray-200 animate-pulse w-20 h-8" />
+            ))}
+          </div>
+          <div className="px-4 py-2 rounded bg-gray-200 animate-pulse w-32 h-8" />
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {/* 1등 (큰 카드) */}
+          <div className="flex flex-col items-start animate-pulse w-full">
+            <div className="w-full aspect-square bg-gray-200 rounded-lg" />
+          </div>
+          {/* 2~5등 (2x2 그리드) */}
+          <div className="grid grid-cols-2 grid-rows-2 gap-4">
+            {[0,1,2,3].map(i => (
+              <div key={i} className="flex flex-col items-start animate-pulse w-full">
+                <div className="w-full aspect-square bg-gray-200 rounded-lg" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
   }
   
   return (

--- a/src/components/projectDetail/ProjectDetail.tsx
+++ b/src/components/projectDetail/ProjectDetail.tsx
@@ -235,10 +235,9 @@ const ProjectDetail = () => {
           {/* 왼쪽: 이미지 캐러셀 스켈레톤 */}
           <div className="flex flex-col">
             <div className="relative aspect-square w-full overflow-hidden rounded-3xl bg-gray-200 animate-pulse flex items-center justify-center">
-              <div className="w-1/2 h-1/2 bg-gray-300 rounded-xl" />
             </div>
             <div className="mt-4 flex justify-center gap-4">
-              {[0,1,2].map(idx => (
+              {[0,1,2,3,4].map(idx => (
                 <div key={idx} className="h-20 w-20 bg-gray-200 rounded-xl animate-pulse" />
               ))}
             </div>


### PR DESCRIPTION
## Summary

>- close [#180 ]

## Tasks
- 메인 페이지 로딩 시 스켈레톤 적용
- 프로젝트 리스트 부분 스피너에서 스켈레톤으로 변경
- 프로젝트 리스트 부분 새로고침 시 "프로젝트가 없습니다" 출력되는 현상 해결

## To Reviewer
- 프로필 편집 페이지의 배송지, 계좌의 경우 탭의 내용과 상관 없이 프로필 편집 내용을 한번에 불러오므로
스켈레톤이 나올 상황이 없어서 추가하지 않음
- 이미지 크기 10MB 제한은 jest 테스트 단계에서 적용할 예정


## Screenshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Seller and project names in project cards are now limited to a single line with ellipsis for overflow, improving text alignment and consistency.
- **New Features**
	- Enhanced loading states across the app with animated skeleton placeholders, replacing previous spinner or text-based loading indicators for category menus, project lists, carousels, and top project sections.
- **Bug Fixes**
	- Improved handling of project list state to avoid rendering issues when data is undefined or empty.
- **Refactor**
	- Updated the rendering logic in carousels and project lists for better responsiveness and consistent visual effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->